### PR TITLE
make os_version a Cow as it's only heap allocated sometimes

### DIFF
--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -12,7 +12,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Microsoft",
                            version: "",
                        });
@@ -22,7 +22,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Microsoft",
                            version: "",
                        });
@@ -32,7 +32,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Google",
                            version: "",
                        });
@@ -42,7 +42,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Apple",
                            version: "",
                        });
@@ -52,7 +52,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Mozilla",
                            version: "",
                        });
@@ -62,7 +62,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Opera",
                            version: "",
                        });
@@ -72,7 +72,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Vivaldi Technologies",
                            version: "",
                        });
@@ -82,7 +82,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Fenrir Inc.",
                            version: "",
                        });
@@ -92,7 +92,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "OS vendor",
                            version: "",
                        });
@@ -102,7 +102,7 @@ lazy_static! {
                            browser_type: "browser",
                            category: "",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Yandex",
                            version: "",
                        });
@@ -112,7 +112,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -122,7 +122,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -132,7 +132,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -142,7 +142,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -152,7 +152,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -162,7 +162,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -172,7 +172,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -182,7 +182,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -192,7 +192,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -202,7 +202,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -212,7 +212,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -222,7 +222,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -232,7 +232,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -242,7 +242,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -252,7 +252,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -262,7 +262,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -272,7 +272,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -282,7 +282,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -292,7 +292,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "pc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -302,7 +302,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -312,7 +312,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -322,7 +322,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -332,7 +332,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -342,7 +342,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -352,7 +352,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -362,7 +362,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -372,7 +372,7 @@ lazy_static! {
                            browser_type: "os",
                            category: "smartphone",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -382,7 +382,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "mobilephone",
                            os: "docomo",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "docomo",
                            version: "",
                        });
@@ -392,7 +392,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "mobilephone",
                            os: "au",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "au",
                            version: "",
                        });
@@ -402,7 +402,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "mobilephone",
                            os: "SoftBank",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "SoftBank",
                            version: "",
                        });
@@ -412,7 +412,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "mobilephone",
                            os: "WILLCOM",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "WILLCOM",
                            version: "",
                        });
@@ -422,7 +422,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "mobilephone",
                            os: "jig",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -432,7 +432,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "mobilephone",
                            os: "emobile",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -442,7 +442,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "mobilephone",
                            os: "SymbianOS",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -452,7 +452,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "mobilephone",
                            os: "Mobile Transcoder",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -462,7 +462,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "Nintendo 3DS",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Nintendo",
                            version: "",
                        });
@@ -472,7 +472,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "Nintendo DSi",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Nintendo",
                            version: "",
                        });
@@ -482,7 +482,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "Nintendo Wii",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Nintendo",
                            version: "",
                        });
@@ -492,7 +492,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "Nintendo Wii U",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Nintendo",
                            version: "",
                        });
@@ -502,7 +502,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "PlayStation Portable",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Sony",
                            version: "",
                        });
@@ -512,7 +512,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "PlayStation Vita",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Sony",
                            version: "",
                        });
@@ -522,7 +522,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "PlayStation 3",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Sony",
                            version: "",
                        });
@@ -532,7 +532,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "PlayStation 4",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Sony",
                            version: "",
                        });
@@ -542,7 +542,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "Xbox 360",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Microsoft",
                            version: "",
                        });
@@ -552,7 +552,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "Xbox One",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Microsoft",
                            version: "",
                        });
@@ -562,7 +562,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "appliance",
                            os: "DigitalTV",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -572,7 +572,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "misc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Apple",
                            version: "",
                        });
@@ -582,7 +582,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "misc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Google",
                            version: "",
                        });
@@ -592,7 +592,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "misc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "Microsoft",
                            version: "",
                        });
@@ -602,7 +602,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "misc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -612,7 +612,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "misc",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -622,7 +622,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -632,7 +632,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -642,7 +642,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -652,7 +652,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -662,7 +662,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -672,7 +672,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -682,7 +682,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -692,7 +692,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -702,7 +702,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -712,7 +712,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -722,7 +722,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -732,7 +732,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -742,7 +742,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -752,7 +752,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -762,7 +762,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -772,7 +772,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -782,7 +782,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -792,7 +792,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -802,7 +802,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -812,7 +812,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -822,7 +822,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -832,7 +832,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -842,7 +842,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -852,7 +852,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -862,7 +862,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -872,7 +872,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -882,7 +882,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -892,7 +892,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -902,7 +902,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });
@@ -912,7 +912,7 @@ lazy_static! {
                            browser_type: "full",
                            category: "crawler",
                            os: "",
-                           os_version: "".to_string(),
+                           os_version: "".into(),
                            vendor: "",
                            version: "",
                        });

--- a/templates/dataset.tmpl
+++ b/templates/dataset.tmpl
@@ -13,7 +13,7 @@ lazy_static! {
                            browser_type: "{{result.browser_type}}",
                            category: "{{result.category}}",
                            os: "{{result.os}}",
-                           os_version: "{{result.os_version}}".to_string(),
+                           os_version: "{{result.os_version}}".into(),
                            vendor: "{{result.vendor}}",
                            version: "{{result.version}}",
                        });


### PR DESCRIPTION
Hey @hhatto,

I played around w/ making os_version a Cow since it's usually a &'a str and only sometimes a String. I don't see any wins in cargo bench but admittedly I haven't looked at these benchmarks, I don't know if they execute any paths that would show differences.

I suspect this change isn't even worth making: it's probably a negligible win if anything, and maybe even a wash as Cow may introduce some dispatch overhead on its own (being an enum).

I figured I'd bring it here for you if you have the time to look into it further (unfortunately I don't) and find any worth to it, otherwise feel free to reject this PR as a failed experiment =]