### PR TITLE
fix: add missing Windows XP x86-64 NT 5.2

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -969,6 +969,7 @@ impl Parser {
             "NT 6.2" => self.lookup_dataset("Win8"),
             "NT 6.1" => self.lookup_dataset("Win7"),
             "NT 6.0" => self.lookup_dataset("WinVista"),
+            "NT 5.2" => self.lookup_dataset("WinXP"),
             "NT 5.1" => self.lookup_dataset("WinXP"),
             "NT 5.0" => self.lookup_dataset("Win2000"),
             "NT 4.0" => self.lookup_dataset("WinNT4"),


### PR DESCRIPTION
User-Agent strings that contain **NT 5.2** were being ignored and that's a valid version for Windows XP on X86-64 architecture. 

This tiny addition properly addresses that, making it possible to parse the example below:

```User-Agent: Mozilla/5.0 (Windows NT 5.2; rv:45.0) Gecko/20100101 Firefox/45.0```